### PR TITLE
i64 to LL fix

### DIFF
--- a/test/unit/app.c
+++ b/test/unit/app.c
@@ -14,9 +14,9 @@
 
 	// time.h implementation https://stackoverflow.com/a/31335254
 	struct timespec { long tv_sec; long tv_nsec; };   //header part
-	#define exp7           10000000i64     //1E+7     //C-file part
-	#define exp9         1000000000i64     //1E+9
-	#define w2ux 116444736000000000i64     //1.jan1601 to 1.jan1970
+	#define exp7           10000000LL     //1E+7     //C-file part
+	#define exp9         1000000000LL     //1E+9
+	#define w2ux 116444736000000000LL     //1.jan1601 to 1.jan1970
 	#define CLOCK_REALTIME 0
 	
 	void unix_time(struct timespec *spec)


### PR DESCRIPTION
Hello Haxiomic,

I'm using gcc on Windows which throws

.\app.c: In function 'unix_time':
.\app.c:19:15: error: invalid suffix "i64" on integer constant
   19 |  #define w2ux 116444736000000000i64     //1.jan1601 to 1.jan1970

because i64 is a Microsoft specific suffix, while compiler standard suffix is LL (long long). After that change, gcc have no more complains, I can link debug.lib without problem like this

 gcc .\app.c -I.\haxe-bin\ .\haxe-bin\obj\lib\Main-debug.lib -g || exit /b

P.S.

While installing haxe-c-bridge, .haxelib directory is created in test/unit mangling all haxe libraries. By deleting or renaming it, all libraries are visible again (including required hxcpp).
